### PR TITLE
Update to .merge.getpartchunks to limit number partitions in a chunk #563

### DIFF
--- a/code/common/merge.q
+++ b/code/common/merge.q
@@ -44,7 +44,7 @@ getpartchunks:{[partdirs;mergelimit]
   /-return list of partitions to be called in batch
   l:(where r={$[z<x+y;y;x+y]}\[0;r;mergelimit]),(select count i from .merge.partsizes)[`x];
   /-where there are more than set partlimit, split the list
-  s:-1_ asc raze {$[(x[y]-x[y-1])<=.merge.partlimit;x[y];x[y], x[y-1] + (v where 0=(v:1+ til x[y] - x[y-1]) mod .merge.partlimit)]}/:[l;til count l];
+  s:-1_distinct asc raze {$[(x[y]-x[y-1])<=.merge.partlimit;x[y];x[y], first each .merge.partlimit cut x[y-1]+til x[y] - x[y-1]]}/:[l;til count l];
   /-return list of partitions
   s cut exec ptdir from t
   };

--- a/code/common/merge.q
+++ b/code/common/merge.q
@@ -1,5 +1,6 @@
 \d .merge
 mergebybytelimit:@[value;`.merge.mergebybytelimit;0b];                        /- merge limit configuration - default is 0b row count limit 1b is byte size limit
+partlimit:@[value;`.merge.partlimit;5]                                        /- limit the number of partitions in a chunk
 
 partsizes:([ptdir:`symbol$()] rowcount:`long$(); bytes:`long$());             /- partsizes table used to keep track of table row count and bytesize estimate when data is written to disk
 
@@ -41,7 +42,11 @@ getpartchunks:{[partdirs;mergelimit]
   /-get list of limits (rowcount or bytesize) to be used to get chunks of partitions to get merged in batch
   r:$[.merge.mergebybytelimit;exec bytes from t;exec rowcount from t];
   /-return list of partitions to be called in batch by merge by part function
-  (where r={$[z<x+y;y;x+y]}\[0;r;mergelimit]) cut exec ptdir from t
+  l:(where r={$[z<x+y;y;x+y]}\[0;r;mergelimit]),(select count i from .merge.partsizes)[`x];
+  /-set a limit to the number of partitions that can be in a chunk
+  s:-1_ asc raze {$[(l[x]-l[x-1])<=.merge.partlimit;l[x];l[x], l[x-1] + (v where 0=(v:1+ til l[x] - l[x-1]) mod .merge.partlimit)]} each til count l;
+  /-return list of partitions
+  s cut exec ptdir from t
   };
 
 /-merge entire partition from temporary storage to permanent storage

--- a/config/settings/wdb.q
+++ b/config/settings/wdb.q
@@ -1,5 +1,6 @@
 // Bespoke WDB config
 .merge.mergebybytelimit:0b                                                                  // merge limit configuration - default is 0b row count limit 1b is byte size limit
+.merge.partlimit:5                                                                          // limit the number of partitions in a chunk					
 \d .wdb
 ignorelist:`heartbeat`logmsg                                                                // list of tables to ignore
 hdbtypes:`hdb                                                                               // list of hdb types to look for and call in hdb reload

--- a/config/settings/wdb.q
+++ b/config/settings/wdb.q
@@ -1,6 +1,6 @@
 // Bespoke WDB config
 .merge.mergebybytelimit:0b                                                                  // merge limit configuration - default is 0b row count limit 1b is byte size limit
-.merge.partlimit:5                                                                          // limit the number of partitions in a chunk					
+.merge.partlimit:1000                                                                       // limit the number of partitions in a chunk					
 \d .wdb
 ignorelist:`heartbeat`logmsg                                                                // list of tables to ignore
 hdbtypes:`hdb                                                                               // list of hdb types to look for and call in hdb reload

--- a/config/settings/wdb.q
+++ b/config/settings/wdb.q
@@ -1,6 +1,6 @@
 // Bespoke WDB config
 .merge.mergebybytelimit:0b                                                                  // merge limit configuration - default is 0b row count limit 1b is byte size limit
-.merge.partlimit:1000                                                                       // limit the number of partitions in a chunk					
+.merge.partlimit:1000                                                                       // limit the number of partitions in a chunk
 \d .wdb
 ignorelist:`heartbeat`logmsg                                                                // list of tables to ignore
 hdbtypes:`hdb                                                                               // list of hdb types to look for and call in hdb reload


### PR DESCRIPTION
Issue #563 
Additional limit has been added to .merge.getpartchunks function to limit the number of partitions that can be merged in a given chunk. Previously many small intraday positions could be merged within the row limit and reading in too many partitions at the same time can lead to a cannot allocate memory error in q. 