### PR TITLE
Fix projection bug in permissions.q

### DIFF
--- a/code/handlers/permissions.q
+++ b/code/handlers/permissions.q
@@ -73,7 +73,7 @@ cloneuser:{[u;unew;p] adduser[unew;ul[0] ;ul[1]; value (string (ul:raze exec aut
 
 / permissions check functions
 / making a dictionary of the parameters and the argument values
-pdict:pdict:{[f;a]
+pdict:{[f;a]
   d:enlist[`]!enlist[::];
   d:d,$[not ca:count a; ();
         f~`select; ();

--- a/code/handlers/permissions.q
+++ b/code/handlers/permissions.q
@@ -79,7 +79,7 @@ pdict:{[f;a]
         f~`select; ();
         (1=count a) and (99h=type first a); first a;
         /if projection first obtain a list of function and fixed parameters (fnfp) 
-        104h=type value f; [fnfp:value[value[f]]; (value[fnfp[0]][1])!(fnfp[1]),a];
+        104h=type value f; [fnfp:value value f; (value[fnfp 0][1])!fnfp[1],a];
         /get paramaters and make a dictionary with the arguments
         101h<>type fp:value[value[f]][1]; fp!a;
         ((),(`$string til ca))!a

--- a/tests/permissions/permissions.csv
+++ b/tests/permissions/permissions.csv
@@ -54,11 +54,11 @@ true,,,q,(`a`b`c!1 4 7)~.pm.expr[`tom;"first each d"],,,test expression with eac
 fail,,,q,.pm.expr[`harry;"first each d"],,,harry doesn't have access to d
 
 comment,,,,,,,test passing a symbol argument to both a lambda function and a projection
-true,,,q,.pm.expr[`tom;({[x;y]y~`ABCD};`x;`ABCD)],,,passing a symbol argument to a lambda function
-true,,,q,.pm.expr[`tom;({[x;y]y~`ABCD}[`x];`ABCD)],,,passing a symbol argument to a projection
+true,,,q,.pm.requ[`tom;({[x;y]y~`ABCD};`x;`ABCD)],,,passing a symbol argument to a lambda function
+true,,,q,.pm.requ[`tom;({[x;y]y~`ABCD}[`x];`ABCD)],,,passing a symbol argument to a projection
 
 comment,,,,,,,test lambdas and string-wrapped lambdas and projections are treated the same
 true,,,q,.pm.requ[`tom; ({x+a};1)]~.pm.requ[`tom; ("{x+a}";1)],,,passing lambda as string returns same as regular lambda
 true,,,q,.pm.requ[`tom; ({x+y}[1];2)]~.pm.requ[`tom; ("{x+y}[1]";2)],,,passing projection as string returns same as regular projection
-fail,,,q,.pm.requ[`harry; ({x+a};1)]~2,,,harry cannot run regular lambda which accesses var a
-fail,,,q,.pm.requ[`harry; ("{x+a}";1)]~2,,,harry cannot run string lambda which accesses var a
+fail,,,q,.pm.expr[`harry; ({x+a};1)]~2,,,harry cannot run regular lambda which accesses var a
+fail,,,q,.pm.expr[`harry; ("{x+a}";1)]~2,,,harry cannot run string lambda which accesses var a

--- a/tests/permissions/permissions.csv
+++ b/tests/permissions/permissions.csv
@@ -67,4 +67,4 @@ comment,,,,,,,test defined projection
 run,,,q,fn:{x+y}[1],,,creating a projection 
 true,,,q,".pm.pdict[`fn;1]~(enlist[`]!enlist[::]),(`x`y)!1 1",,,check output is as expected
 true,,,q,.pm.expr[`tom;(`fn;1)]~2,,,tom can run projection
-false,,,q,.pm.expr[`harry;(`fn;1)]~2,,,harry cannot run projection
+fail,,,q,.pm.expr[`harry;(`fn;1)]~2,,,harry cannot run projection

--- a/tests/permissions/permissions.csv
+++ b/tests/permissions/permissions.csv
@@ -62,3 +62,9 @@ true,,,q,.pm.requ[`tom; ({x+a};1)]~.pm.requ[`tom; ("{x+a}";1)],,,passing lambda 
 true,,,q,.pm.requ[`tom; ({x+y}[1];2)]~.pm.requ[`tom; ("{x+y}[1]";2)],,,passing projection as string returns same as regular projection
 fail,,,q,.pm.expr[`harry; ({x+a};1)]~2,,,harry cannot run regular lambda which accesses var a
 fail,,,q,.pm.expr[`harry; ("{x+a}";1)]~2,,,harry cannot run string lambda which accesses var a
+
+comment,,,,,,,test defined projection
+run,,,q,fn:{x+y}[1],,,creating a projection 
+true,,,q,".pm.pdict[`fn;1]~(enlist[`]!enlist[::]),(`x`y)!1 1",,,check output is as expected
+true,,,q,.pm.expr[`tom;(`fn;1)]~2,,,tom can run projection
+false,,,q,.pm.expr[`harry;(`fn;1)]~2,,,harry cannot run projection

--- a/tests/permissions/permissions.csv
+++ b/tests/permissions/permissions.csv
@@ -54,8 +54,8 @@ true,,,q,(`a`b`c!1 4 7)~.pm.expr[`tom;"first each d"],,,test expression with eac
 fail,,,q,.pm.expr[`harry;"first each d"],,,harry doesn't have access to d
 
 comment,,,,,,,test passing a symbol argument to both a lambda function and a projection
-true,,,q,.pm.requ[`tom;({[x;y]y~`ABCD};`x;`ABCD)],,,passing a symbol argument to a lambda function
-true,,,q,.pm.requ[`tom;({[x;y]y~`ABCD}[`x];`ABCD)],,,passing a symbol argument to a projection
+true,,,q,.pm.expr[`tom;({[x;y]y~`ABCD};`x;`ABCD)],,,passing a symbol argument to a lambda function
+true,,,q,.pm.expr[`tom;({[x;y]y~`ABCD}[`x];`ABCD)],,,passing a symbol argument to a projection
 
 comment,,,,,,,test lambdas and string-wrapped lambdas and projections are treated the same
 true,,,q,.pm.requ[`tom; ({x+a};1)]~.pm.requ[`tom; ("{x+a}";1)],,,passing lambda as string returns same as regular lambda

--- a/tests/permissions/permissions.csv
+++ b/tests/permissions/permissions.csv
@@ -65,6 +65,5 @@ fail,,,q,.pm.expr[`harry; ("{x+a}";1)]~2,,,harry cannot run string lambda which 
 
 comment,,,,,,,test defined projection
 run,,,q,fn:{x+y}[1],,,creating a projection 
-true,,,q,".pm.pdict[`fn;1]~(enlist[`]!enlist[::]),(`x`y)!1 1",,,check output is as expected
 true,,,q,.pm.expr[`tom;(`fn;1)]~2,,,tom can run projection
 fail,,,q,.pm.expr[`harry;(`fn;1)]~2,,,harry cannot run projection


### PR DESCRIPTION
Add a section to the conditional to specifically deal with projections in pdict function.

This closes #591 