### PR TITLE
Remove repeated line and fix cache bug

### DIFF
--- a/code/handlers/ldap.q
+++ b/code/handlers/ldap.q
@@ -39,7 +39,6 @@ initialise:{[lib]                                                     / initiali
  };
 
 sessionID:0i
-.ldap.initialise hsym .ldap.lib
 
 cache:([user:`$()]; pass:(); server:`$(); port:`int$(); time:`timestamp$(); attempts:`long$(); success:`boolean$(); blocked:`boolean$());  / create table to store login attempts
 
@@ -84,7 +83,7 @@ login:{[user;pass]                                              / validate login
     .[.ldap.bind;(.ldap.sessionID;dict);enlist[`ReturnCode]!enlist -2i]                 / attempt authentication
   ];
  
-  `.ldap.cache upsert (user;np;`$.ldap.server;.ldap.port;.z.p; $[0=authorised[`ReturnCode];0;1+0^incache`attempts] ;authorised[`ReturnCode]~0i;0b);  / upsert details of current attempt
+  `.ldap.cache upsert (user;np;`$.ldap.server;.ldap.port;.z.p; 1+0^incache`attempts ;authorised[`ReturnCode]~0i;0b);  / upsert details of current attempt
 
   $[authorised[`ReturnCode]~0i;                                                 / display authentication status message
     .ldap.out"successfully authenticated user ",;


### PR DESCRIPTION
.ldap.initialise was called twice meaning that regardless if ldap was enabled it was still called.

Start a test TorQ process with ldap enabled, and qcon in using correct user name and password
.z.u returns username:
![zu good](https://github.com/DataIntellectTech/TorQ/assets/131150806/87fcaa63-a83c-40c8-b88d-296acf34a9ec)
The q process returns authenticated message (if .ldap.debug is set to 2i in default.q):
![fry authenticated](https://github.com/DataIntellectTech/TorQ/assets/131150806/5eb54c46-4923-4f6e-b958-e09cf7ef8100)
The cache is updated:
![authenticated cache](https://github.com/DataIntellectTech/TorQ/assets/131150806/f3abd7c6-2247-45e2-ad2b-a464a7f30db4)

qcon using wrong credentials:
.z.u doesn't return a value:
![zu bad](https://github.com/DataIntellectTech/TorQ/assets/131150806/ebf88c8f-15a7-4d12-a5d8-fbdb7a036c41)
The q process returns a failed to authenticate message
![failed to authenticate fr](https://github.com/DataIntellectTech/TorQ/assets/131150806/ca071138-7b2c-4aec-acc7-8356b993eda9)
Continued attempts will block the user
![blocked cache](https://github.com/DataIntellectTech/TorQ/assets/131150806/7fd867c1-6004-4bec-bc2f-c559e60c840a)

Fixed bug in .ldap.cache where attempts counter was wrong for authenticated users