### PR TITLE
Can specify multiple LDAP servers

### DIFF
--- a/code/handlers/ldap.q
+++ b/code/handlers/ldap.q
@@ -7,14 +7,12 @@
 enabled:    @[value;`enabled;.z.o~`l64]                            / whether authentication is enabled
 lib:        `$getenv[`KDBLIB],"/",string[.z.o],"/kdbldap";         / ldap library location
 debug:      @[value;`debug;0i]                                     / debug level for ldap library: 0i = none, 1i=normal, 2i=verbose
-server:     @[value;`server;"localhost"];                          / name of ldap server
-port:       @[value;`port;0i];                                     / port for ldap server
+servers:    @[value;`servers; enlist `$"ldap://localhost:0"];      / symbol-list of <schema>://<host>:<port> 
 blocktime:  @[value;`blocktime; 0D00:30:00];                       / time before blocked user can attempt authentication
 checklimit: @[value;`checklimit;3];                                / number of attempts before user is temporarily blocked
 checktime:  @[value;`checktime;0D00:05];                           / period for user to reauthenticate without rechecking LDAP server
 buildDNsuf: @[value;`buildDNsuf;""];                               / suffix used for building bind DN
 buildDN:    @[value;`buildDN;{{"uid=",string[x],",",buildDNsuf}}]; / function to build bind DN
-schema:     @[value;`schema;"ldap"];                               / schema for ldap
 version:    @[value;`version;3];                                   / ldap version number 
 
 out:{if[debug;:.lg.o[`ldap] x]};
@@ -32,7 +30,7 @@ initialise:{[lib]                                                     / initiali
   .ldap.interactive_bind_s:lib 2:(`kdbldap_interactive_bind_s;5);
   .ldap.search_s:lib 2:(`kdbldap_search_s;8);
   .ldap.unbind_s:lib 2:(`kdbldap_unbind_s;1);
-  r:.ldap.init[.ldap.sessionID;enlist `$.ldap.schema,"://",.ldap.server,":",string .ldap.port];
+  r:.ldap.init[.ldap.sessionID; .ldap.servers];
   if[0<>r;.ldap.err "Error initialising LDAP: ",.ldap.err2string[r]];
   s:.ldap.setOption[.ldap.sessionID;`LDAP_OPT_PROTOCOL_VERSION;.ldap.version];
   if[0<>s;.ldap.err "Error setting LDAP option: ",.ldap.err2string[s]];

--- a/config/settings/default.q
+++ b/config/settings/default.q
@@ -135,15 +135,13 @@ errortolerance:3f		// and to an error state when it hasn't heartbeated in errort
 
 enabled:0b                                  // whether ldap authentication is enabled
 debug:0i				    // debug level for ldap library: 0i = none, 1i=normal, 2i=verbose
-server:"localhost";                         // name of ldap server
-port:0i;                                    // port for ldap server
+servers: enlist `$"ldap://localhost:0";     // ldap server address(es)
 version:3;                                  // ldap version number
 blocktime:0D00:30:00;                       // time before blocked user can attempt authentication
 checklimit:3;                               // number of attempts before user is temporarily blocked
 checktime:0D00:05;                          // period for user to reauthenticate without rechecking LDAP server
 buildDNsuf:"";                              // suffix used for building bind DN
 buildDN:{"uid=",string[x],",",buildDNsuf};  // function to build bind DN
-schema:"ldap"                               // ldap schema
 
 // broadcast publishing
 \d .u

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -453,8 +453,7 @@ Default parameters in the ldap namespace are set in {TORQHOME}/config/settings/d
 | :----------------: | :-----------------: |
 |      enabled       |  Whether ldap authentication is enabled  |
 |       debug        |  Whether logging message are written to console  |
-|       server       |  Host for ldap server.   |
-|        port        |  Port number for ldap server.  |
+|       servers      |  `<schema>://<host>:<port>` address(es) of server(s) to connect to   |
 |      version       |  Ldap version number.    |
 |     blocktime      |  Time that must elapse before a blocked user can attempt to authenticate. If set to 0Np then the user is permanently blocked until an admin unblocks them. |
 |     checklimit     |  Login attempts before user is blocked.  |
@@ -462,7 +461,7 @@ Default parameters in the ldap namespace are set in {TORQHOME}/config/settings/d
 |     buildDNsuf     |  Suffix for building distinguished name. |
 |      buildDN       |  Function to build distiniguished name.  |
 
-To get started the following will need altered from their default values: enabled, port, server, buildDNsuf.
+To get started the following will need altered from their default values: enabled, servers, buildDNsuf.
 
 The value buildDNsuf is required to build a users bind_dn from the supplied username and is called by the function buildDN. An example definition is:
 


### PR DESCRIPTION
The Kx LDAP library allows you to pass in a list of LDAP servers to initialise against. I believe this is done for redundancy - e.g. passing in a list of `(bad server address; good server address)` still works.

The TorQ wrapper doesn't currently support passing multiple servers in, as it constructs the address by joining schema - host - port. Since there's a chance people may use different combinations of schemas and ports, I thought it best to do away with these variables and require the user to provide `.ldap.servers` - a list of `schema://server:port`, which gets passed through to the underlying LDAP library.