### PR TITLE
EOP function for WDB/ RDB's for diconnecting from TP and removing unwanted data

### DIFF
--- a/code/common/finspace.q
+++ b/code/common/finspace.q
@@ -41,3 +41,10 @@ notifyhdb:{[cluster;changeset]
       .aws.update_kx_cluster_databases[string[cluster];.aws.sdbs[.aws.db[.finspace.database;changeset[`id];.aws.cache["CACHE_1000";"/"]]];.aws.sdep["NO_RESTART"]]
       // TODO - Also need to figure out the ideal logic if a changeset fails to create. Possibly recreate and re-run notifyhd
    }
+
+// function to close connection to TP and remove unwanted data in WDB and RDB's 
+eopdatacleanup:{[dict]
+    hclose each exec w from .servers.SERVERS where proctype = `segmentedtickerplant;
+    // function to parse icounts dict and remove all data after a given index for RDB and WDB's 
+    {[sym;ind]delete from sym where i >= ind}'[key dict;first each value dict]
+ }

--- a/code/common/finspace.q
+++ b/code/common/finspace.q
@@ -44,7 +44,8 @@ notifyhdb:{[cluster;changeset]
 
 // function to close connection to TP and remove unwanted data in WDB and RDB's 
 eopdatacleanup:{[dict]
-    hclose each exec w from .servers.SERVERS where proctype = `segmentedtickerplant;
+    // close off each subsription by handle to the tickerplant  
+    hclose each distinct exec w from .sub.SUBSCRIPTIONS;
     // function to parse icounts dict and remove all data after a given index for RDB and WDB's 
-    {[sym;ind]delete from sym where i >= ind}'[key dict;first each value dict]
+    {[t;ind]delete from t where i >= ind}'[key dict;first each value dict];
  }


### PR DESCRIPTION
## Issue Number
625
## Pull Request Label
Enhancement
## Team Member(s) who solved this issue
Tom Watters
## Summary
Added a data cleanup function for use in finspace by the RDB's and WDB's being deactivated state. 
## Details
When EOP is called this function will close the connection to the tickerplant and clear all unwanted data after the given index in .u.icounts being passed in. 
## Checklist from Issue of Things Solved
- Phase 2 feature 
