### PR TITLE
Fix Gateway syncexec bug

### DIFF
--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -451,7 +451,10 @@ syncexecjt:{[query;servertype;joinfunction;timeout]
  asyncexecjpts[query;servertype;joinfunction;();timeout;1b];
  // defer response
  e:@[{-30!x;1b};(::);0b];
- if[not e;[.lg.o[`syncexecjt;"failed to defer; query passed to syncexecjpre36"];:syncexecjpre36[query;servertype;joinfunction]]] 
+ if[not e;
+     .lg.o[`syncexecjt;"failed to defer; query passed to syncexecjpre36"];
+     :syncexecjpre36[query;servertype;joinfunction];
+  ];
  }; 
 
 $[.z.K < 3.6;

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -409,7 +409,7 @@ syncexecjpre36:{[query;servertype;joinfunction]
    @[neg .z.w;.gw.formatresponse[0b;0b;"Incorrect function used: asyncexec"];()];
    :();
    ];
- if[not[.gw.synccallsallowed] and .z.K<3.6;.gw.formatresponse[0b;1b;"synchronous calls are not allowed"]];
+ if[not[.gw.synccallsallowed];.gw.formatresponse[0b;1b;"synchronous calls are not allowed"]];
  // check if the gateway allows the query to be called
  if[.gw.permissioned;
    if[not .pm.allowed [.z.u;query];

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -446,15 +446,15 @@ syncexecjpre36:{[query;servertype;joinfunction]
 
 syncexecjt:{[query;servertype;joinfunction;timeout]
  // can only be used on 3.6 + 
- // use async call back function, flag it as sync
- // doesn't make sense to allow specification of a callback for sync requests
- asyncexecjpts[query;servertype;joinfunction;();timeout;1b];
  // defer response
  e:@[{-30!x;1b};(::);0b];
  if[not e;
      .lg.o[`syncexecjt;"failed to defer; query passed to syncexecjpre36"];
      :syncexecjpre36[query;servertype;joinfunction];
-  ];
+  ];   
+ // if deferring was succesful use async call back function, flag it as sync
+ // doesn't make sense to allow specification of a callback for sync requests
+ asyncexecjpts[query;servertype;joinfunction;();timeout;1b];
  }; 
 
 $[.z.K < 3.6;

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -450,7 +450,8 @@ syncexecjt:{[query;servertype;joinfunction;timeout]
  // doesn't make sense to allow specification of a callback for sync requests
  asyncexecjpts[query;servertype;joinfunction;();timeout;1b];
  // defer response
- @[-30!;(::);()];
+ e:@[{-30!x;1b};(::);0b];
+ if[not e;[.lg.o[`syncexecjt;"failed to defer; query passed to syncexecjpre36"];:syncexecjpre36[query;servertype;joinfunction]]] 
  }; 
 
 $[.z.K < 3.6;


### PR DESCRIPTION
Fixing a bug where using .gw.syncexec to query the gateway using qcon or HTTP results in an empty return, now the correct result will be returned if synccallsallowed is set to 1b and an error message if it is set to 0b.