### PR TITLE
Rts start stall

### DIFF
--- a/code/common/finspace.q
+++ b/code/common/finspace.q
@@ -50,7 +50,7 @@ eopdatacleanup:{[dict]
     // function to parse icounts dict and remove all data after a given index for RDB and WDB's 
     {[t;ind]delete from t where i >= ind}'[key dict;first each value dict];
  }
-//send signal to the old rts that new processes are running and ready to take over at start of new period
+//set rdbready to true after signal received from the old rdb, that new processes are running and ready to take over at start of new period
 newrdbup:{[]
         .lg.o[`newrdbup;"received signal from next period rdb, setting rdbready to true"]
         @[`.finspace;`rdbready;:;1b];

--- a/code/common/finspace.q
+++ b/code/common/finspace.q
@@ -5,6 +5,7 @@ enabled:@[value;`enabled;0b];                               //whether the applic
 database:@[value;`database;"database"];                     //name of the finspace database applicable to a certain RDB cluster - Not used if on prem
 
 hdbclusters:@[value;`hdbclusters;enlist `cluster];          //list of clusters to be reloaded during the rdb end of day (and possibly other uses)
+rdbready:@[value;`rdbready;0b];                             //whether or not the rdb is running and ready to take over at the next period- set to false by default
 
 / Runs a .aws api until a certain status has been received
 checkstatus:{[apicall;status;frequency;timeout]
@@ -49,3 +50,8 @@ eopdatacleanup:{[dict]
     // function to parse icounts dict and remove all data after a given index for RDB and WDB's 
     {[t;ind]delete from t where i >= ind}'[key dict;first each value dict];
  }
+//send signal to the old rts that new processes are running and ready to take over at start of new period
+newrdbup:{[]
+        .lg.o[`newrdbup;"received signal from next period rdb, setting rdbready to true"]
+        @[`.finspace;`rdbready;:;1b];
+        };


### PR DESCRIPTION
1. Added rdbready variable in code/common/finspace.q in order to flag wether or not the next periods rdb is up and ready
2. Added newrdbup[] to finspace.q to change the rdbready variable when the next process completes start up and signals it is ready
3. Added newrdbready to .rdb namespace (declared in code/processes/rdb.q) which , at the end of start up, connects to the old processes and sends them a signal to call .finspace.newrdbup to change their respective instances of .finspace.rdbready.
(tested on homer & finspace. works as expected)