### PR TITLE
Remove cluster.csv for finspace connection strings

### DIFF
--- a/code/handlers/finspaceservers.q
+++ b/code/handlers/finspaceservers.q
@@ -1,22 +1,16 @@
 .servers.FINSPACEDISC:@[value; `.servers.FINSPACEDISC; 0b];
 .servers.FINSPACECLUSTERSFILE:@[value; `.servers.FINSPACECLUSTERSFILE; hsym `];
 
-.servers.readclustersfile:{[]
-    if[null .servers.FINSPACECLUSTERSFILE; {.lg.e[`readclustersfile; "no finspace clusters file defined"]}];
-    :("SSSS**"; enlist ",") 0: .servers.FINSPACECLUSTERSFILE;
+.servers.listfinspaceclusters:{
+    :@[.aws.list_kx_clusters; `; {.lg.e[`listfinspaceclusters; "Failed to get finspace clusters using the finspace API - ",x]}];
     };
 
-.servers.getfinspaceclusters:{[]
-    expclusters:@[.servers.readclustersfile; `; {.lg.e[`getfinspaceclusters; "Failed to get read clusters.csv when using -  ",x]}];
-    availclusters:@[.aws.list_kx_clusters; `; {.lg.e[`getfinspaceclusters; "Failed to get finspace clusters using the finspace API - ",x]}];
-    :expclusters ij `cluster_name`cluster_type xkey select `$cluster_name, `$cluster_type, `$status from availclusters where status like "RUNNING";
-    };
-
-.servers.getfinspaceconn:{[ptype; pname]
-    id:.j.j[(ptype;pname)];
-    cluster:first exec cluster_name from .servers.getfinspaceclusters[] where proctype=ptype, procname = pname;
+.servers.getfinspaceconn:{[pname]
+    id:.Q.s1 pname;
+    runningclusters:select `$cluster_name, `$cluster_type, status from .servers.listfinspaceclusters[] where status like "RUNNING";
+    cluster:first exec cluster_name from runningclusters where pname = cluster_name;
 
     if[null cluster; .lg.w[`finspaceconn; "no available finspace cluster found for ",id]; :`];
     conn:@[.aws.get_kx_connection_string; cluster; {[id;e] .lg.e[`finspaceconn; "failed to get connection string for ",id," via aws api - ",e]; :`}[id;]];
-    :`$conn;
+    :`$conn;    
     };

--- a/code/handlers/finspaceservers.q
+++ b/code/handlers/finspaceservers.q
@@ -7,10 +7,9 @@
 
 .servers.getfinspaceconn:{[pname]
     id:.Q.s1 pname;
-    runningclusters:select `$cluster_name, `$cluster_type, status from .servers.listfinspaceclusters[] where status like "RUNNING";
-    cluster:first exec cluster_name from runningclusters where pname = cluster_name;
+    cluster:first exec `$cluster_name from .servers.listfinspaceclusters[] where status like "RUNNING",(`$cluster_name)=pname;
 
     if[null cluster; .lg.w[`finspaceconn; "no available finspace cluster found for ",id]; :`];
     conn:@[.aws.get_kx_connection_string; cluster; {[id;e] .lg.e[`finspaceconn; "failed to get connection string for ",id," via aws api - ",e]; :`}[id;]];
-    :`$conn;    
+    :`$conn;
     };

--- a/code/handlers/trackservers.q
+++ b/code/handlers/trackservers.q
@@ -189,7 +189,7 @@ retryrows:{[rows]
 // in this case we need to generate the connection string using the AWS api
 getconnectionstring:{[proctype;procname;hpup]
     if[`finspace~ `tcp ^ .servers.SOCKETTYPE proctype;
-        :.servers.getfinspaceconn[proctype; procname]];
+        :.servers.getfinspaceconn[procname]];
     :hpup;
     };
 


### PR DESCRIPTION
## Author

eugene.temlock@dataintellect.com

## Summary

change finspaceservers API to ignore clusters.csv and match processname against the name of the cluster itself. Use the AWS native Q API to list clusters