### PR TITLE
Unregister from gw finspace torQ compatibiity

### DIFF
--- a/code/common/finspace.q
+++ b/code/common/finspace.q
@@ -58,7 +58,8 @@ newrdbup:{[]
 
  // clustername must be of type string
 deletecluster:{[clustername]
-  if[10h<>fType:type clustername; .lg.o[`deletecluster;"clustername must be of type string: 10h, got ",-3!fType]; :(::)];
+  if[not any (10h;-11h)=fType:type clustername; .lg.e[`deletecluster;"clustername must be of type string or symbol: 10h -11h, got ",-3!fType]; :(::)];
+  if[-11h~fType; clustername:string clustername];
   .lg.o[`deletecluster;"Going to delete ",$[""~clustername;"current cluster";"cluster named: ",clustername]];
   .aws.delete_kx_cluster[clustername]; // calling this on an empty string deletes self
   // TODO ZAN Error trap

--- a/code/common/finspace.q
+++ b/code/common/finspace.q
@@ -58,6 +58,7 @@ newrdbup:{[]
 
  // clustername must be of type string
 deletecluster:{[clustername]
+  if[10h<>fType:type clustername; .lg.o[`deletecluster;"clustername must be of type string: 10h, got ",-3!fType]; :(::)];
   .lg.o[`deletecluster;"Going to delete ",$[""~clustername;"current cluster";"cluster named: ",clustername]];
   .aws.delete_kx_cluster[clustername]; // calling this on an empty string deletes self
   // TODO ZAN Error trap

--- a/code/common/finspace.q
+++ b/code/common/finspace.q
@@ -56,7 +56,6 @@ newrdbup:{[]
       @[`.finspace;`rdbready;:;1b];
  };
 
- // clustername must be of type string
 deletecluster:{[clustername]
   if[not any (10h;-11h)=fType:type clustername; .lg.e[`deletecluster;"clustername must be of type string or symbol: 10h -11h, got ",-3!fType]; :(::)];
   if[-11h~fType; clustername:string clustername];

--- a/code/common/finspace.q
+++ b/code/common/finspace.q
@@ -55,3 +55,11 @@ newrdbup:{[]
       .lg.o[`newrdbup;"received signal from next period rdb, setting rdbready to true"];
       @[`.finspace;`rdbready;:;1b];
  };
+
+ // clustername must be of type string
+deletecluster:{[clustername]
+  .lg.o[`deletecluster;"Going to delete ",$[""~clustername;"current cluster";"cluster named: ",clustername]];
+  .aws.delete_kx_cluster[clustername]; // calling this on an empty string deletes self
+  // TODO ZAN Error trap
+  // Test this with invalid cluster names and catch to show error messages
+  };

--- a/code/gateway/gatewaylib.q
+++ b/code/gateway/gatewaylib.q
@@ -93,6 +93,6 @@ getserverscross:{[req;att;besteffort]
  (key s)!distinct each' flip each util[w]`found
  }
 
- addserversfromconnectiontable:{
+addserversfromconnectiontable:{
  {.gw.addserverattr'[x`w;x`proctype;x`attributes]}[select w,proctype,attributes from .servers.SERVERS where ((proctype in x) or x~`ALL),not w in ((0;0Ni),exec handle from .gw.servers where active)];}
 

--- a/code/gateway/gatewaylib.q
+++ b/code/gateway/gatewaylib.q
@@ -92,3 +92,7 @@ getserverscross:{[req;att;besteffort]
  /- return the parameters which should be queried for
  (key s)!distinct each' flip each util[w]`found
  }
+
+ addserversfromconnectiontable:{
+ {.gw.addserverattr'[x`w;x`proctype;x`attributes]}[select w,proctype,attributes from .servers.SERVERS where ((proctype in x) or x~`ALL),not w in ((0;0Ni),exec handle from .gw.servers where active)];}
+

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -193,7 +193,9 @@ deleteresult:{[queryid] .gw.results : (queryid,()) _ .gw.results}
 
 // add a result coming back from a server
 addserverresult:{[queryid;results]
- serverid:first exec serverid from .gw.servers where active, handle=.z.w;
+ serverid:$[@[get;`.finspace.enabled;0b];
+    first exec serverid from .gw.servers where handle=.z.w;
+    first exec serverid from .gw.servers where active, handle=.z.w];
  if[queryid in key .gw.results;
   .[`.gw.results;(queryid;1;.gw.results[queryid;1;;0]?serverid;1);:;results];
   .[`.gw.results;(queryid;1;.gw.results[queryid;1;;0]?serverid;2);:;1b]

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -523,10 +523,6 @@ while[0 = count .servers.getservers[`proctype;`discovery;()!();0b;1b];
  .servers.startup[];
  .servers.retrydiscovery[]]
 
-// add servers from the standard connections table
-addserversfromconnectiontable:{
- {.gw.addserverattr'[x`w;x`proctype;x`attributes]}[select w,proctype,attributes from .servers.SERVERS where ((proctype in x) or x~`ALL),not w in ((0;0Ni),exec handle from .gw.servers where active)];}
-
 // When new connections come in from the discovery service, try to reconnect
 .servers.addprocscustom:{[connectiontab;procs]
  // retry connections

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -295,7 +295,7 @@ removeserverhandle:{[serverh]
  // finspace check
  if[@[value;`.finspace.enabled;0b] and @[value;`.finspace.dereginprog;0b];
    .finspace.deregserverids:.finspace.deregserverids _ serverid;
-   .finspace.dereginprog:"b"$count .finspace.deregserverids _ 0N;
+   .finspace.dereginprog:0<count .finspace.deregserverids _ 0N;
    ];
 
  runnextquery[];

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -193,7 +193,7 @@ deleteresult:{[queryid] .gw.results : (queryid,()) _ .gw.results}
 
 // add a result coming back from a server
 addserverresult:{[queryid;results]
- serverid:$[@[get;`.finspace.enabled;0b];
+ serverid:$[@[value;`.finspace.enabled;0b];
     first exec serverid from .gw.servers where handle=.z.w;
     first exec serverid from .gw.servers where active, handle=.z.w];
  if[queryid in key .gw.results;


### PR DESCRIPTION
## Author

eugene.temlock@dataintellect.com

## Summary

TorQ changes required for: https://github.com/DataIntellectTech/TorQ-Amazon-FinSpace-Starter-Pack/pull/90

## Changes

- move definition of addserversfromconnectiontable to gatewaylib.q, so it can be overwritten in other TorQ Apps while retaining original definition for standard TorQ
- addserverresult will ignore whether the server is active or not IF .finspace.enabled, and populate .gw.results accordingly
- adding deletecluster logic to finspace.q