### PR TITLE
Data access api fix

### DIFF
--- a/code/common/dataaccess.q
+++ b/code/common/dataaccess.q
@@ -2,6 +2,9 @@
 
 \d .dataaccess
 
+//set the default properties path to ` allow initialisaiton intra-process
+tablepropertiespath:@[value;`.dataaccess.tablepropertiespath;`]
+
 // to set table properties path passed from -dataaccess parameter
 settablepropertiespath:{[]
   if[not`dataaccess in key .proc.params;.lg.e[`.dataaccess.settablepropertiespath;"No table properties passed by -dataaccess parameter"]];

--- a/code/common/dataaccess.q
+++ b/code/common/dataaccess.q
@@ -2,7 +2,7 @@
 
 \d .dataaccess
 
-//set the default properties path to ` allow initialisaiton intra-process
+//set the default tableproperties path to ` allow initialisation intra-process
 tablepropertiespath:@[value;`.dataaccess.tablepropertiespath;`]
 
 // to set table properties path passed from -dataaccess parameter


### PR DESCRIPTION
**ISSUE**
Currently the dataaccess api cannot be initialised intra process using .dataaccess.init[] (without first passing dataaccess as a param at start up) due to .dataaccess.tablepropertiespath being undefined. This is due to the conditional at the bottom of the script only setting this variable if -dataaccess is included in the procparams.

**FIX**
initialise .dataaccess.tablepropertiespath to ` at beginning of script.