### PR TITLE
Updating sctp code to remove the projection, in 4.1 this would cause a rank error

### DIFF
--- a/code/segmentedtickerplant/sctp.q
+++ b/code/segmentedtickerplant/sctp.q
@@ -46,7 +46,7 @@ init:{
 .dotz.set[`.z.pc;{[f;x] @[f;x;()];
   if[.sctp.chainedtp;
     if[.sctp.tph=x; .lg.e[`.z.pc;"lost connection to tickerplant : ",string .sctp.tickerplantname];exit 1]]
-    }@[value;.dotz.getcommand[`.z.pc];{{}}];];
+    }@[value;.dotz.getcommand[`.z.pc];{{}}]];
 
 // Extract data from incoming table as a list
 upd:{[t;x]


### PR DESCRIPTION
With the update to 4.1, one of the changes (worded as a change, seems more like a bug) was as follows:
projection creation from a lambda/foreign will result in a rank error if too many parameters defined, e.g.
 q){x}[;1]
 'rank
With this, the only part of TorQ that had this was in the sctp code, removing this stops the projection and functionality works as expected