### PR TITLE
KxDashboards - Debugging .kxdash.exec

### DIFF
--- a/code/gateway/kxdash.q
+++ b/code/gateway/kxdash.q
@@ -6,7 +6,7 @@ dashparams:`o`w`r`limit!(0;0i;0i;0W)
 
 // function to be called from the dashboards
 dashexec:{[q;s;j]
- .gw.asyncexecjpt[(dashremote;q;dashparams);(),s;dashjoin[j];();0Wn]
+ .gw.syncexecj[q;(),s;j]
  }
 
 // execute the request
@@ -31,7 +31,6 @@ dashps:{
    [dashparams::`o`w`r`limit!(last value x 1;x 2;x 3;x[4;0]);
     // execute the query part, which must look something like
     // .kxdash.dashexec["select from t";`rdb`hdb;raze]
-    value x[4;1];
     ];
    //
    value x]
@@ -42,6 +41,9 @@ dashps:{
 // reformat those responses to look the same
 formatresponse:{[status;sync;result]
   if[`kxdash~first result;
+  .test.status:status;
+  .test.sync:sync;
+  .test.result:result;
   res:last result;
   :$[res`status;
     (`.dash.rcv_msg;res`w;res`o;res`r;res`result);
@@ -57,5 +59,5 @@ init:{
  // incorporate dashps into the .z.ps definition
  .dotz.set[`.z.ps;{x@y;.kxdash.dashps y}@[value;.dotz.getcommand[`.z.ps];{{value x}}]];
  };
- 
+
 if[enabled;init[]];

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -421,7 +421,7 @@ asyncexec:asyncexecjpt[;;raze;();0Wn]
 // execute a synchronous query
 syncexecjpre36:{[query;servertype;joinfunction]
  // Check correct function called
- if[(.z.w<>0)&(.z.w in key .gw.call)&not .gw.call .z.w;
+ if[(.z.w<>0)&(.z.w in key .gw.call)&(not .gw.call .z.w)& not @[value;`.kxdash.enabled;0b];
    @[neg .z.w;.gw.formatresponse[0b;0b;"Incorrect function used: asyncexec"];()];
    :();
    ];


### PR DESCRIPTION
It looks like we'll have to use a sync response.
Dashboards are config'd to send down a negative handle, but the wrapper that the dashboards add looks like the below:
```
"({[f;w;r;x;u].dash.u:u;res:.[f;(w;r;x);{[w;r;e]neg[.z.w](`.dash.snd_err;w;r;e)}[w;r]];.dash.u:`;res};{[o;w;r;x]neg[.z.w](`.dash.rcv_msg;w;o;r;x[0] sublist value x 1)}[2];7i;904i;(2000i;\".kxdash.dashexec[\\\"select first time from trade\\\";`rdb`hdb;raze]\");`default)"
```
The `x[0] sublist value x 1` always gives a (::) result on async methods. This causes dashboards to recognise no result has been returned. Due to this, I have converted to sync.

Additionally, TorQ has a condition checking for negative handles vs sync/async. I have had to add a condition to ignore this if .kxdash.enabled is set to 1b.

As below, this is tested and working through the front-end.
<img width="539" alt="image" src="https://github.com/DataIntellectTech/TorQ/assets/166718222/d9cbfa5b-afa2-49c1-95cb-36c095b5016c">
