### PR TITLE
Add kdbtplog to segmentedchainedtickerplant

### DIFF
--- a/config/settings/segmentedchainedtickerplant.q
+++ b/config/settings/segmentedchainedtickerplant.q
@@ -21,7 +21,8 @@ multilogperiod:0D01;
 errmode:1b;
 batchmode:`defaultbatch;                          // [autobatch|defaultbatch|immediate]
 customcsv:hsym first .proc.getconfigfile["stpcustom.csv"];
-replayperiod:`day                                 // [period|day|prior]
+replayperiod:`day;                                 // [period|day|prior]
+kdbtplog:`$getenv`KDBTPLOG;
 
 \d .proc
 


### PR DESCRIPTION
`kdbtplog` was recently added to `settings/segmentedtickerplant.q`

If you have a `segmentedchainedtickerplant` process that does not inherit `segmentedtickerplant` as a parentproctype, it will not pick up this config, and the process will fail to startup as `kdbtplog` is undefined.

Therefore adding a copy to `settings/segmentedchainedtickerplant.q`. This brings it in line with the rest of the ctp config, where it has its own copy of each of the `.stplg` variables.

Thanks