### PR TITLE
fix idbreload issues

### DIFF
--- a/code/processes/idb.q
+++ b/code/processes/idb.q
@@ -56,7 +56,7 @@ symfilehaschanged:{[]
 /- checks if count of partitions has changed since last reload of the IDB. Records new partition count if changed.
 /- the default writedown method doesn't need db reloading as no new directory is being created there.
 partitioncounthaschanged:{[]
-    if[writedownmode~`default;:0b];
+    if[(1j~partitionsize)&writedownmode~`default;:0b];
     $[partitionsize<>c:count key idbdir;[partitionsize::c; 1b];0b]
  };
 

--- a/code/processes/idb.q
+++ b/code/processes/idb.q
@@ -55,6 +55,7 @@ symfilehaschanged:{[]
 
 /- checks if count of partitions has changed since last reload of the IDB. Records new partition count if changed.
 /- the default writedown method doesn't need db reloading as no new directory is being created there.
+/- First check is to ensure that a single intraday partition exists (so loadidb doesn't fail)
 partitioncounthaschanged:{[]
     if[(1j~partitionsize)&writedownmode~`default;:0b];
     $[partitionsize<>c:count key idbdir;[partitionsize::c; 1b];0b]

--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -421,7 +421,7 @@ endofdaysort:{[dir;pt;tablist;writedownmode;mergelimits;hdbsettings;mergemethod]
         endofdaysortdate[dir;pt;key tablist;hdbsettings]
     ];
     /- run steps to rollover idb
-    idbreload[currentpartition+1];
+    idbreload[pt+1];
     /- reset compression level (.z.zd)
     resetcompression[16 0 0]
     };


### PR DESCRIPTION
Think I've understood the context here
* wdb.q change simple enough, just using the local instead of the global variable
* idb just cleaned up clients suggested conditional, removed their "1b" option to conform with original logic of the function.