### PR TITLE
Remove kill command override

### DIFF
--- a/torq.sh
+++ b/torq.sh
@@ -150,12 +150,6 @@ top() {
 stop() {
   procno=$(awk '/,'$1',/{print NR}' "$CSVPATH")
   host=$(getfield "$procno" "host")
-  if [[ $host == "localhost" || $host == `hostname -i`  ||
-        ${hostips[@]}  =~ $host || ${hostnames[@]} =~ $host ]]; then
-    kcmd="kill -15"
-  else
-    kcmd="$cmd"
-  fi
   if [[ -z $(findproc "$1") ]]; then
     echo "$(date '+%H:%M:%S') | $1 is not currently running"
   else
@@ -166,7 +160,7 @@ stop() {
     if [[ ! $port =~ ^[0-9]+$ ]]; then
       port=$(($(eval echo \$$port)))
     fi
-    eval "$kcmd `lsof -i :$port -sTCP:LISTEN | awk '{if(NR>1)print $2}'`"
+    eval "$cmd `lsof -i :$port -sTCP:LISTEN | awk '{if(NR>1)print $2}'`"
   fi
  }
 


### PR DESCRIPTION
Fixes https://github.com/DataIntellectTech/TorQ/issues/695

This override appears to be an unintended side effect of introducing localhost-specific script logic: https://github.com/DataIntellectTech/TorQ/commit/4bf0e95fa069658e7dc04985382b3cfe67ee45f7#diff-5efc7986b95cbbfb1bc8a0cb35ac172a70f3498b8c9542cd8e77fb874bffb177R141