### PR TITLE
.z.exit update when STP is in memory batch mode

### DIFF
--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -284,8 +284,7 @@ init:{[dbname]
   if[not x~0i;.lg.e[`stpexit;"Bad exit!"];:()];
   .lg.o[`stpexit;"Exiting process"];
 
-// Flushing in memory data to disk during unexpected shutdown when batchmode is set to memorybatch
-  if[.stplg.batchmode=`memorybatch;
+  if[.stplg.batchmode=`memorybatch;      // Flushing in memory data to disk during unexpected shutdown when batchmode is set to memorybatch
      .lg.o[`stpexit;"STP shutdown unexpectedly, batchmode = `memorybatch, therefore flushing any remaining data to the on-disk log file"];
      .stplg.zts.memorybatch[];
      .lg.o[`stpexit; "Complete!"]

--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -284,7 +284,8 @@ init:{[dbname]
   if[not x~0i;.lg.e[`stpexit;"Bad exit!"];:()];
   .lg.o[`stpexit;"Exiting process"];
 
-  if[.stplg.batchmode=`memorybatch;      // Flushing in memory data to disk during unexpected shutdown when batchmode is set to memorybatch
+  // flushing in memory data to disk during unexpected shutdown when batchmode is set to memorybatch
+  if[.stplg.batchmode=`memorybatch;      
      .lg.o[`stpexit;"STP shutdown unexpectedly, batchmode = `memorybatch, therefore flushing any remaining data to the on-disk log file"];
      .stplg.zts.memorybatch[];
      .lg.o[`stpexit; "Complete!"]

--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -286,9 +286,10 @@ init:{[dbname]
 
 // Flushing in memory data to disk during unexpected shutdown when batchmode is set to memorybatch
   if[.stplg.batchmode=`memorybatch;
-     .lg.o[`flushToDisk;"STP shutdown unexpectedly, batchmode = `memorybatch, therefore flushing any remaining data to the on-disk log file"];
+     .lg.o[`stpexit;"STP shutdown unexpectedly, batchmode = `memorybatch, therefore flushing any remaining data to the on-disk log file"];
      .stplg.zts.memorybatch[];
-     .lg.o[`flushToDisk; "Complete!"]];
+     .lg.o[`stpexit; "Complete!"]
+    ];
 
   // exit before logs are touched if process is an sctp NOT in create mode
   if[.sctp.chainedtp and not .sctp.loggingmode=`create; :()];

--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -283,6 +283,13 @@ init:{[dbname]
 .dotz.set[`.z.exit;{
   if[not x~0i;.lg.e[`stpexit;"Bad exit!"];:()];
   .lg.o[`stpexit;"Exiting process"];
+
+// Flushing in memory data to disk during unexpected shutdown when batchmode is set to memorybatch
+  if[.stplg.batchmode=`memorybatch;
+     .lg.o[`flushToDisk;"STP shutdown unexpectedly, batchmode = `memorybatch, therefore flushing any remaining data to the on-disk log file"];
+     .stplg.zts.memorybatch[];
+     .lg.o[`flushToDisk; "Complete!"]];
+
   // exit before logs are touched if process is an sctp NOT in create mode
   if[.sctp.chainedtp and not .sctp.loggingmode=`create; :()];
   .lg.o[`stpexit;"Closing off log files"];


### PR DESCRIPTION
When the STP is in memorybatch mode, .z.exit will now update the log file(s) with whatever data is in memory during unexpected shutdown.