### PR TITLE
Fix: default tempdir to be an hsym in tickerlogreplay.q

### DIFF
--- a/code/processes/tickerlogreplay.q
+++ b/code/processes/tickerlogreplay.q
@@ -27,7 +27,7 @@ clean:@[value;`clean;1b]                                                // clean
 sortcsv:@[value;`sortcsv;hsym first .proc.getconfigfile["sort.csv"]]    // location of  sort csv file
 compression:@[value;`compression;()];                                   // specify the compress level, empty list if no required
 partandmerge:@[value;`partandmerge;0b];                                 // setting to do a replay where the data is partitioned and then merged on disk
-tempdir:@[value;`tempdir;`:tempmergedir];                               // location to save data for partandmerge replay
+tempdir:hsym @[value;`tempdir;`:tempmergedir];                               // location to save data for partandmerge replay
 mergenumrows:@[value;`mergenumrows;10000000];                           // default number of rows for merge process
 mergenumtab:@[value;`mergenumtab;`quote`trade!10000 50000];             // specify number of rows per table for merge process
 mergenumbytes:@[value;`mergenumbytes;500000000];                        // default number of bytes for merge process
@@ -107,6 +107,7 @@ if[partandmerge and sortafterreplay;(sortafterreplay:0b; .lg.o[`replayinit;"Sett
 \d .replay
 
 .lg.o[`replayinit;"hdb directory is set to ",string hdbdir:hsym hdbdir];
+.lg.o[`replayinit;"tempdir directory is set to ",string tempdir:hsym tempdir];
 
 // the path to the table to save
 pathtotable:{[h;p;t] `$(string .Q.par[h;partitiontype$p;t]),"/"}


### PR DESCRIPTION
This PR updates tickerlogreplay.q to ensure tempdir and hdbdir to be an hsym as related to issue #699  