### PR TITLE
Fix(windows): Make os.sleep work with redirected stdin

### DIFF
--- a/code/common/os.q
+++ b/code/common/os.q
@@ -19,7 +19,7 @@ Vex:not 0h~type key`.@
 df:{(`$("/";"\\")[NT]sv -1_v;`$-1#v:("/";"\\")[NT]vs pth(string x;x)[10h=type x])} 
 run:{system"q ",x}
 kill:{[p]@[(`::p);"\\\\";1];}
-sleep:{x:string x; system("sleep ",x;"timeout /t ",x," >nul")[NT]}
+sleep:{x:string x; system("sleep ",x;"powershell.exe -NoProfile -NonInteractive -Command Start-Sleep -Seconds ",x)[NT]}
 pthq:{[x] $[10h=type x;ssr [x;"\\";"/"];`$ -1 _ ssr [string (` sv x,`);"\\";"/"]]}
 ren:{[x;y]
  / Convert the incoming q values into OS path strings.


### PR DESCRIPTION
Replace timeout.exe with non-interactive PowerShell Start-Sleep for Windows.

timeout.exe expects an interactive console and can fail when stdin is redirected, which can prevent RDB/IDB startup retries from working correctly and surface misleading os file-load errors.

Using PowerShell Start-Sleep removes the dependency on interactive stdin while preserving the existing sleep behavior.